### PR TITLE
feature: update dependencies and integrate Strapi design system theming for overlay

### DIFF
--- a/admin/src/components/StraplightOverlay.tsx
+++ b/admin/src/components/StraplightOverlay.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useStraplight, SearchResult } from '../hooks/useStraplight';
+import { Box, Flex, Divider, Typography, Loader } from '@strapi/design-system';
+import { Search } from '@strapi/icons';
 
 const OVERLAY_STYLES = `
+#straplight-portal input::placeholder {
+  color: inherit;
+  opacity: 0.6;
+}
 @keyframes straplight-fade-in {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -14,59 +20,6 @@ const OVERLAY_STYLES = `
   to { transform: rotate(360deg); }
 }
 `;
-
-// Strapi stores theme preference in localStorage under 'STRAPI_THEME'
-// Values: 'light', 'dark', or 'system'
-function resolveIsDark(): boolean {
-  const stored = localStorage.getItem('STRAPI_THEME') || 'system';
-  if (stored === 'dark') return true;
-  if (stored === 'light') return false;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
-}
-
-function useIsDarkMode() {
-  return resolveIsDark();
-}
-
-// Colors matching Strapi's design system
-const themes = {
-  light: {
-    bg: '#ffffff',
-    bgHover: '#f6f6f9',
-    bgSelected: '#f0f0ff',
-    text: '#32324d',
-    textMuted: '#8e8ea9',
-    border: '#eaeaef',
-    inputText: '#32324d',
-    badge: '#f6f6f9',
-    kbd: '#f6f6f9',
-    kbdBorder: '#dcdce4',
-    kbdText: '#666687',
-    backdrop: 'rgba(0, 0, 0, 0.4)',
-    shadow: '0 16px 70px rgba(0, 0, 0, 0.2)',
-    spinnerTrack: '#eaeaef',
-    spinnerAccent: '#4945ff',
-  },
-  dark: {
-    bg: '#212134',
-    bgHover: '#2a2a3e',
-    bgSelected: '#2e2e48',
-    text: '#eaeaef',
-    textMuted: '#a5a5ba',
-    border: '#3d3d57',
-    inputText: '#eaeaef',
-    badge: '#2e2e48',
-    kbd: '#2e2e48',
-    kbdBorder: '#3d3d57',
-    kbdText: '#a5a5ba',
-    backdrop: 'rgba(0, 0, 0, 0.6)',
-    shadow: '0 16px 70px rgba(0, 0, 0, 0.5)',
-    spinnerTrack: '#3d3d57',
-    spinnerAccent: '#7b79ff',
-  },
-};
-
-type Theme = typeof themes.light;
 
 export function StraplightOverlay() {
   const {
@@ -81,8 +34,6 @@ export function StraplightOverlay() {
     navigateToResult,
   } = useStraplight();
 
-  const dark = useIsDarkMode();
-  const t = dark ? themes.dark : themes.light;
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -111,110 +62,95 @@ export function StraplightOverlay() {
     <>
       <style>{OVERLAY_STYLES}</style>
       {/* Backdrop */}
-      <div
+      <Box
         onClick={close}
+        background='rgba(0, 0, 0, 0.5)'
+        position='fixed'
+        zIndex={99999}
+        animation='straplight-fade-in 0.15s ease-out'
         style={{
-          position: 'fixed',
           inset: 0,
-          backgroundColor: t.backdrop,
           backdropFilter: 'blur(4px)',
-          zIndex: 99999,
-          animation: 'straplight-fade-in 0.15s ease-out',
         }}
       />
       {/* Modal */}
-      <div
+      <Box
         onKeyDown={onKeyDown}
-        style={{
-          position: 'fixed',
-          top: 'calc(50% - 50px)',
-          left: '50%',
-          width: '580px',
-          maxWidth: 'calc(100vw - 32px)',
-          maxHeight: '440px',
-          backgroundColor: t.bg,
-          borderRadius: '12px',
-          boxShadow: t.shadow,
-          zIndex: 100000,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          animation: 'straplight-slide-in 0.2s ease-out 0.05s both',
-        }}
+        background="neutral0"
+        shadow="filterShadow"
+        borderRadius="12px"
+        maxHeight="440px"
+        maxWidth="calc(100vw - 32px)"
+        overflow="hidden"
+        position='fixed'
+        top='calc(50% - 50px)'
+        left='50%'
+        width='580px'
+        zIndex={100000}
+        animation='straplight-slide-in 0.2s ease-out 0.05s both'
       >
-        {/* Search input */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            padding: '14px 16px',
-            borderBottom: `1px solid ${t.border}`,
-            gap: '10px',
-          }}
+        <Box
+          paddingLeft={4}
+          paddingRight={4}
+          paddingTop={3}
+          paddingBottom={3}
         >
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke={t.textMuted}
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search content..."
-            style={{
-              flex: 1,
-              border: 'none',
-              outline: 'none',
-              fontSize: '16px',
-              fontFamily: 'inherit',
-              color: t.inputText,
-              backgroundColor: 'transparent',
-            }}
-          />
-          {loading && (
-            <div
-              style={{
-                width: '18px',
-                height: '18px',
-                border: `2px solid ${t.spinnerTrack}`,
-                borderTopColor: t.spinnerAccent,
-                borderRadius: '50%',
-                animation: 'straplight-spin 0.6s linear infinite',
-              }}
-            />
-          )}
-        </div>
 
+          {/* Search input */}
+          <Flex
+            items="center"
+            gap="10px"
+          >
+            <Box
+              display="contents"
+              color="neutral400"
+            >
+              <Search width={20} height={20}/>
+            </Box>
+            <Box
+              color="neutral700"
+              flex="1"
+            >
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
+                placeholder="Search content..."
+                style={{
+                  border: 'none',
+                  outline: 'none',
+                  fontSize: '16px',
+                  fontFamily: 'inherit',
+                  color: "inherit",
+                  backgroundColor: 'transparent',
+                }}
+              />
+            </Box>
+            {loading && <Loader small />}
+          </Flex>
+        </Box>
+        <Divider />
         {/* Results */}
-        <div
+        <Box
+          flex="1"
+          overflow="auto"
           ref={listRef}
-          style={{
-            flex: 1,
-            overflowY: 'auto',
-            padding: results.length > 0 ? '8px' : '0',
-          }}
+          padding={results.length > 0 ? 2 : 0}
         >
           {query.trim() && !loading && results.length === 0 && (
-            <div
-              style={{
-                padding: '32px 16px',
-                textAlign: 'center',
-                color: t.textMuted,
-                fontSize: '14px',
-              }}
+            <Box
+              color="neutral600"
+              paddingLeft={4}
+              paddingRight={4}
+              paddingTop={8}
+              paddingBottom={8}
+              textAlign="center"
             >
-              No results found
-            </div>
+              <Typography>
+                No results found
+              </Typography>
+            </Box>
           )}
           {results.map((result, index) => (
             <ResultItem
@@ -222,29 +158,29 @@ export function StraplightOverlay() {
               result={result}
               isSelected={index === selectedIndex}
               onClick={() => navigateToResult(result)}
-              t={t}
             />
           ))}
-        </div>
+        </Box>
 
         {/* Footer */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '16px',
-            padding: '10px 16px',
-            borderTop: `1px solid ${t.border}`,
-            fontSize: '12px',
-            color: t.textMuted,
-          }}
+        <Divider />
+        <Box
+          paddingLeft={4}
+          paddingRight={4}
+          paddingTop={3}
+          paddingBottom={3}
         >
-          <span><Kbd t={t}>{'\u2191\u2193'}</Kbd> navigate</span>
-          <span><Kbd t={t}>{'\u23CE'}</Kbd> open</span>
-          <span><Kbd t={t}>esc</Kbd> close</span>
-          <span style={{ marginLeft: 'auto' }}><Kbd t={t}>{modKey}+K</Kbd> toggle</span>
-        </div>
-      </div>
+          <Flex
+            color="neutral600"
+            gap="16px"
+          >
+            <Typography fontSize="12px"><Kbd>{'\u2191\u2193'}</Kbd> navigate</Typography>
+            <Typography fontSize="12px"><Kbd>{'\u23CE'}</Kbd> open</Typography>
+            <Typography fontSize="12px"><Kbd>esc</Kbd> close</Typography>
+            <Typography fontSize="12px" style={{ marginLeft: 'auto' }}><Kbd>{modKey}+K</Kbd> toggle</Typography>
+          </Flex>
+        </Box>
+      </Box>
     </>
   );
 }
@@ -253,108 +189,113 @@ function ResultItem({
   result,
   isSelected,
   onClick,
-  t,
 }: {
   result: SearchResult;
   isSelected: boolean;
   onClick: () => void;
-  t: Theme;
 }) {
+  const [hovered, setHovered] = useState(false);
+
   return (
-    <div
+    <Box
+      paddingLeft={3}
+      paddingRight={3}
+      paddingTop={2}
+      paddingBottom={2}
+      borderRadius="8px"
+      transition="background-color 0.1s"
+      cursor="pointer"
+      background={(isSelected || hovered) ? 'neutral150' : 'transparent'}
       onClick={onClick}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '10px 12px',
-        borderRadius: '8px',
-        cursor: 'pointer',
-        backgroundColor: isSelected ? t.bgSelected : 'transparent',
-        transition: 'background-color 0.1s',
-      }}
-      onMouseEnter={(e) => {
-        if (!isSelected)
-          (e.currentTarget as HTMLElement).style.backgroundColor = t.bgHover;
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLElement).style.backgroundColor = isSelected
-          ? t.bgSelected
-          : 'transparent';
-      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
-      <div
-        style={{
-          flex: 1,
-          overflow: 'hidden',
-          marginRight: '12px',
-          display: 'flex',
-          alignItems: 'baseline',
-          gap: '8px',
-        }}
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
       >
-        <span
-          style={{
-            fontSize: '14px',
-            color: t.text,
-            fontWeight: isSelected ? 600 : 400,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            flexShrink: 1,
-            minWidth: 0,
-          }}
+        <Box
+          flex="1"
+          overflow="hidden"
+          marginRight={3}
         >
-          {result.label}
-        </span>
-        {result.fields && result.fields.length > 0 && (
-          <span
-            style={{
-              fontSize: '12px',
-              color: t.textMuted,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              flexShrink: 2,
-              minWidth: 0,
-            }}
+          <Flex
+            alignItems="baseline"
+            gap="8px"
           >
-            {result.fields.map((f) => f.value).join(' · ')}
-          </span>
-        )}
-      </div>
-      <span
-        style={{
-          fontSize: '11px',
-          color: t.textMuted,
-          backgroundColor: t.badge,
-          padding: '2px 8px',
-          borderRadius: '4px',
-          whiteSpace: 'nowrap',
-          flexShrink: 0,
-        }}
-      >
-        {result.contentType}
-      </span>
-    </div>
+            <Box
+              shrink="0"
+              minWidth={0}
+            >
+              <Typography
+                fontWeight={isSelected ? 600 : 400}
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {result.label}
+              </Typography>
+            </Box>
+            {result.fields && result.fields.length > 0 && (
+              <Box
+                shrink="1"
+                minWidth={0}
+              >
+                <Typography
+                  fontSize="12px"
+                  textColor="neutral600"
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {result.fields.map((f) => f.value).join(' · ')}
+                </Typography>
+              </Box>
+            )}
+          </Flex>
+        </Box>
+        <Box
+          color="neutral600"
+          background="neutral150"
+          paddingLeft={2}
+          paddingRight={2}
+          paddingTop={1}
+          paddingBottom={1}
+          borderRadius="4px"
+          shrink="0"
+        >
+          <Typography fontSize="11px">
+            {result.contentType}
+          </Typography>
+        </Box>
+      </Flex>
+    </Box>
   );
 }
 
-function Kbd({ children, t }: { children: React.ReactNode; t: Theme }) {
+function Kbd({ children }: { children: React.ReactNode }) {
   return (
-    <kbd
-      style={{
-        display: 'inline-block',
-        padding: '1px 5px',
-        fontSize: '11px',
-        fontFamily: 'inherit',
-        color: t.kbdText,
-        backgroundColor: t.kbd,
-        border: `1px solid ${t.kbdBorder}`,
-        borderRadius: '4px',
-      }}
+    <Box
+      display="inline-block"
+      borderColor="neutral200"
+      background="neutral150"
+      borderRadius="4px"
     >
-      {children}
-    </kbd>
+      <kbd
+        style={{
+          display: 'inline-block',
+          padding: '1px 5px',
+          fontSize: '11px',
+          fontFamily: 'inherit',
+          borderRadius: '4px',
+        }}
+      >
+        {children}
+      </kbd>
+    </Box>
   );
 }

--- a/admin/src/components/StraplightProvider.tsx
+++ b/admin/src/components/StraplightProvider.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { DesignSystemProvider, lightTheme, darkTheme } from '@strapi/design-system';
+import { StraplightOverlay } from './StraplightOverlay';
+
+function resolveIsDark() {
+  const stored = localStorage.getItem('STRAPI_THEME') || 'system';
+  if (stored === 'dark') return true;
+  if (stored === 'light') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+export function StraplightProvider() {
+  const [isDark, setIsDark] = useState(resolveIsDark);
+
+  useEffect(() => {
+    function update() { setIsDark(resolveIsDark()); }
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', update);
+    window.addEventListener('storage', update);
+    // 'storage' only fires in other tabs; patch setItem to catch same-tab changes
+    const originalSetItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = function(key: string, value: string) {
+      originalSetItem(key, value);
+      if (key === 'STRAPI_THEME') update();
+    };
+    return () => {
+      mq.removeEventListener('change', update);
+      window.removeEventListener('storage', update);
+      localStorage.setItem = originalSetItem;
+    };
+  }, []);
+
+  return (
+    <DesignSystemProvider theme={isDark ? darkTheme : lightTheme}>
+      <StraplightOverlay />
+    </DesignSystemProvider>
+  );
+}

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -34,13 +34,13 @@ export default {
 
     // Mount the persistent overlay on document.body
     import('react-dom/client').then(({ createRoot }) => {
-      import('./components/StraplightOverlay').then(({ StraplightOverlay }) => {
+      import('./components/StraplightProvider').then(({ StraplightProvider }) => {
         import('react/jsx-runtime').then(({ jsx }) => {
           const el = document.createElement('div');
           el.id = 'straplight-portal';
           document.body.appendChild(el);
           const root = createRoot(el);
-          root.render(jsx(StraplightOverlay, {}));
+          root.render(jsx(StraplightProvider, {}));
         });
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "straplight",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "straplight",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@strapi/design-system": "^2.0.0-rc.30",
-        "@strapi/icons": "^2.0.0-rc.30",
-        "react-intl": "^8.1.3"
+        "@strapi/design-system": "^2.2.0",
+        "@strapi/icons": "^2.2.0",
+        "react-intl": "^7.1.5"
       },
       "devDependencies": {
         "@strapi/sdk-plugin": "^5.4.0",
@@ -1114,7 +1114,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
@@ -1124,7 +1123,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/react": {
@@ -1177,7 +1175,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
@@ -1685,58 +1682,58 @@
       "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
-      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/intl-localematcher": "0.8.1",
-        "decimal.js": "^10.6.0",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
-      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.8.1"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
-      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-skeleton-parser": "2.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
-      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-4.1.2.tgz",
-      "integrity": "sha512-V60fNY/X/7zqmRffr7qPwscGmVGYDmlKF069mSQ2a/7fE22q602NtIfOQY8vzRA63Gr/O/U6vjRVBHMabrnA9A==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.8.tgz",
+      "integrity": "sha512-LWXgwI5zTMatvR8w8kCNh/priDTOF/ZssokMBHJ7ZWXFoYLVOYo0EJERD9Eajv+xsfQO1QkuAt77KWQ1OI4mOQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "intl-messageformat": "11.1.2",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "intl-messageformat": "10.7.18",
+        "tslib": "^2.8.0"
       },
       "peerDependencies": {
         "typescript": "^5.6.0"
@@ -1814,13 +1811,12 @@
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
-      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "tslib": "^2.8.1"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@hapi/bourne": {
@@ -4843,6 +4839,92 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/admin/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/admin/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -4852,6 +4934,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/admin/node_modules/execa": {
@@ -4968,6 +5063,32 @@
         }
       }
     },
+    "node_modules/@strapi/admin/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@strapi/admin/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4997,6 +5118,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@strapi/cloud-cli": {
@@ -5191,6 +5322,92 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/content-manager/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-manager/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-manager/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-manager/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -5200,6 +5417,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/content-manager/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/content-manager/node_modules/intl-messageformat": {
@@ -5239,6 +5469,32 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/content-manager/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -5356,6 +5612,92 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/content-releases/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-releases/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-releases/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-releases/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -5365,6 +5707,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/content-releases/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/content-releases/node_modules/intl-messageformat": {
@@ -5404,6 +5759,32 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/content-releases/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -5532,6 +5913,99 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/content-type-builder/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/@strapi/design-system/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-type-builder/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -5541,6 +6015,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/content-type-builder/node_modules/intl-messageformat": {
@@ -5589,6 +6076,42 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@strapi/core": {
@@ -5806,6 +6329,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/@strapi/core/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@strapi/data-transfer": {
       "version": "5.35.0",
       "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-5.35.0.tgz",
@@ -5870,9 +6403,9 @@
       }
     },
     "node_modules/@strapi/design-system": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
-      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.2.0.tgz",
+      "integrity": "sha512-NO8DhQfApMXlEUeuUG39pKmPGcYCJZjApjPqtPbDFUr434WTeon/vJtJv/fqRs5GFPaJqqDH7YPlpZlJX3z3bA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-json": "6.0.1",
@@ -5896,9 +6429,9 @@
         "@radix-ui/react-tabs": "1.0.4",
         "@radix-ui/react-tooltip": "1.0.7",
         "@radix-ui/react-use-callback-ref": "1.0.1",
-        "@strapi/ui-primitives": "2.1.2",
+        "@strapi/ui-primitives": "2.2.0",
         "@uiw/react-codemirror": "4.22.2",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "react-remove-scroll": "2.5.10"
       },
       "peerDependencies": {
@@ -5906,6 +6439,49 @@
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
         "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/design-system/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/design-system/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/@strapi/design-system/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/email": {
@@ -6017,6 +6593,92 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/email/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/email/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/email/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/email/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -6026,6 +6688,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/email/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/email/node_modules/intl-messageformat": {
@@ -6067,6 +6742,42 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@strapi/email/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/email/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@strapi/generators": {
@@ -6209,6 +6920,99 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/i18n/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/i18n/node_modules/@strapi/design-system/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@strapi/i18n/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/i18n/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/i18n/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -6218,6 +7022,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/i18n/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/i18n/node_modules/intl-messageformat": {
@@ -6268,10 +7085,46 @@
         }
       }
     },
+    "node_modules/@strapi/i18n/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/i18n/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@strapi/icons": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
-      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.2.0.tgz",
+      "integrity": "sha512-wVItrWIDYtvGpv1S5Lg580b5PXH2iw6dgcFnri5vVz4qZDP6ZOTpLmkwZybkfZcpIzq1KkjKyA1JZ6NLBE59cQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0",
@@ -6315,6 +7168,16 @@
       "engines": {
         "node": ">=20.0.0 <=24.x.x",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@strapi/openapi/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@strapi/pack-up": {
@@ -6548,6 +7411,92 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@strapi/review-workflows/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/review-workflows/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -6557,6 +7506,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/review-workflows/node_modules/intl-messageformat": {
@@ -6596,6 +7558,32 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -6942,6 +7930,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@strapi/strapi/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@strapi/strapi/node_modules/prettier": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
@@ -7054,6 +8055,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/@strapi/types/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@strapi/typescript-utils": {
       "version": "5.35.0",
       "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-5.35.0.tgz",
@@ -7111,9 +8122,9 @@
       }
     },
     "node_modules/@strapi/ui-primitives": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
-      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.2.0.tgz",
+      "integrity": "sha512-CGvyIr+D7ZEuP9x4bmUFUiilHZwCkftiwV8Kh+o/jBETVlm5/8SrE5wihuyqSQTya1NxTHu0O8RTNkX0U6p8bQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.0.1",
@@ -7143,6 +8154,18 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@strapi/ui-primitives/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@strapi/ui-primitives/node_modules/aria-hidden": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
@@ -7153,6 +8176,31 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@strapi/ui-primitives/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@strapi/upload": {
@@ -7327,6 +8375,92 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/@strapi/upload/node_modules/@strapi/design-system": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.1.2.tgz",
+      "integrity": "sha512-0EFhstDnQeXC2wuxKdyguo/7l1kswfXvBq/mZYguzisiAqJ0QhCRHPuoTgVkkB59npAZEY7jSFMTb20XKa8jIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.1.2",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@strapi/icons": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.1.2.tgz",
+      "integrity": "sha512-RnVKuhO8gCWbpIjIs0Qfm0rmOLUrvmCR33AHHClwi7L5i9UwTqVG8ajRPVGptG2dC5vA6JCigsVPAS6yXjUTHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@strapi/ui-primitives": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.1.2.tgz",
+      "integrity": "sha512-9PLnqJjWBSFlWmZdz0zLcgOhda6tIF/6tu8ZoX7JudlAg9gv8KElEHR0ZbACuH/+b+8BBpQ5fU7rcnMJyK6lJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "@tanstack/react-virtual": "^3.10.8",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/upload/node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -7336,6 +8470,19 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@strapi/upload/node_modules/execa": {
@@ -7452,6 +8599,32 @@
         }
       }
     },
+    "node_modules/@strapi/upload/node_modules/react-remove-scroll": {
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
+      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.6",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@strapi/upload/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -7467,6 +8640,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@strapi/utils": {
@@ -7580,6 +8763,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@strapi/utils/node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@swc/core": {
@@ -7831,12 +9024,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.18",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz",
-      "integrity": "sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==",
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.22.tgz",
+      "integrity": "sha512-EaOrBBJLi3M0bTMQRjGkxLXRw7Gizwntoy5E2Q2UnSbML7Mo2a1P/Hfkw5tw9FLzK62bj34Jl6VNbQfRV6eJcA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.18"
+        "@tanstack/virtual-core": "3.13.22"
       },
       "funding": {
         "type": "github",
@@ -7848,9 +9041,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.18",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz",
-      "integrity": "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==",
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.22.tgz",
+      "integrity": "sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8389,7 +9582,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -8410,7 +9603,6 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8420,7 +9612,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8483,7 +9675,6 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
       "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/through": {
@@ -9125,6 +10316,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/argparse": {
@@ -9777,7 +10981,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10655,7 +11858,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -10718,7 +11920,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
@@ -10756,7 +11957,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
@@ -12732,6 +13932,19 @@
         "node": "*"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -14182,15 +15395,15 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.2.tgz",
-      "integrity": "sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==",
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/invariant": {
@@ -14705,7 +15918,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -15116,6 +16328,16 @@
         "co-body": "^6.1.0",
         "formidable": "^2.0.1",
         "zod": "^3.19.1"
+      }
+    },
+    "node_modules/koa-body/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/koa-compose": {
@@ -15609,6 +16831,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -15719,7 +16942,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -16742,6 +17964,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/microseconds": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
@@ -17029,7 +18264,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17334,6 +18568,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/nodemon/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/nodemon/node_modules/readdirp": {
@@ -18236,17 +19483,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -18661,7 +19907,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/preferred-pm": {
@@ -19113,7 +20358,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19167,7 +20411,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19181,7 +20424,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19236,22 +20478,22 @@
       "license": "MIT"
     },
     "node_modules/react-intl": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-8.1.3.tgz",
-      "integrity": "sha512-eL1/d+uQdnapirynOGAriW0K9uAoyarjRGL3V9LaTRuohNSvPgCfJX06EZl5M52h/Hu7Gz7A1sD7dNHcos1lNg==",
+      "version": "7.1.14",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-7.1.14.tgz",
+      "integrity": "sha512-VE/0Wi/lHJlBC7APQpCzLUdIt3GB5B0GZrRW8Q+ACbkHI4j+Wwgg9J1TniN6zmLHmPH5gxXcMy+fkSPfw5p1WQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "@formatjs/intl": "4.1.2",
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "@formatjs/intl": "3.1.8",
         "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/react": "16 || 17 || 18 || 19",
         "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "11.1.2",
-        "tslib": "^2.8.1"
+        "intl-messageformat": "10.7.18",
+        "tslib": "^2.8.0"
       },
       "peerDependencies": {
-        "@types/react": "19",
-        "react": "19",
+        "react": "16 || 17 || 18 || 19",
         "typescript": "^5.6.0"
       },
       "peerDependenciesMeta": {
@@ -19370,31 +20612,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-remove-scroll": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
-      "integrity": "sha512-m3zvBRANPBw3qxVVjEIPEQinkcwlFZ4qyomuWVpNJdv4c6MvHfXV0C3L9Jx5rr3HeBHKNRX+1jreB5QloDIJjA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.6",
-        "react-style-singleton": "^2.2.1",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.0",
-        "use-sidecar": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-remove-scroll-bar": {
@@ -20523,7 +21740,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sharp": {
@@ -20953,7 +22169,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -21301,7 +22516,6 @@
       "version": "6.3.8",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.8.tgz",
       "integrity": "sha512-Kq/W41AKQloOqKM39zfaMdJ4BcYDw/N5CIq4/GTI0YjU6pKcZ1KKhk6b4du0a+6RA9pIfOP/eu94Ge7cu+PDCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
@@ -21335,7 +22549,6 @@
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -21364,7 +22577,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stylis": {
@@ -21686,19 +22898,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/title-case": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-4.3.2.tgz",
@@ -21946,7 +23145,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -23719,11 +24918,12 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "test:ts:back": "run -T tsc -p server/tsconfig.json"
   },
   "dependencies": {
-    "@strapi/design-system": "^2.0.0-rc.30",
-    "@strapi/icons": "^2.0.0-rc.30",
-    "react-intl": "^8.1.3"
+    "@strapi/design-system": "^2.2.0",
+    "@strapi/icons": "^2.2.0",
+    "react-intl": "^7.1.5"
   },
   "devDependencies": {
     "@strapi/sdk-plugin": "^5.4.0",


### PR DESCRIPTION
## What

This PR fixes two issues:

### 1. `npm install` fails due to incompatible `react-intl` version

`react-intl@8.x` requires React 19 as a peer dependency, but the plugin declares `react@^18.3.1` in both `devDependencies` and `peerDependencies`.  This caused an `ERESOLVE` error for anyone trying to install or develop the plugin. [See here](https://github.com/formatjs/formatjs/blob/main/packages/react-intl/CHANGELOG.md#800-2025-12-15)

**Fix:** Downgraded `react-intl` to `^7.1.5`, the last major version with React 18 support. 

### 2. Overlay uses hardcoded colors instead of Strapi's theme

The overlay was using hardcoded hex color values, causing it to look out of place if the admin panel uses custom theme colors.

**Fix:** Updated `@strapi/design-system` and `@strapi/icons` to `^2.2.0`. Added `StraplightProvider` — a wrapper component that supplies `DesignSystemProvider` from `@strapi/design-system` with the correct theme (`lightTheme` / `darkTheme`), resolved from Strapi's `STRAPI_THEME` localStorage value. The provider reactively updates when the user switches themes in Strapi's settings (including same-tab changes) or when the OS theme changes. The overlay itself now uses design system tokens (e.g. `neutral0`, `neutral100`) and components throughout.

Closes #3 